### PR TITLE
Add --locked to cargo-leptos install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a template for the [Leptos](https://github.com/leptos-rs/leptos) web fra
 If you don't have `cargo-leptos` installed you can install it with
 
 ```bash
-cargo install cargo-leptos
+cargo install cargo-leptos --locked
 ```
 
 Then either click the "Use this template" button in the Github UI or run


### PR DESCRIPTION
Cargo Leptos will not install on Windows without adding `--locked`. Updating readme accordingly.

See https://github.com/leptos-rs/cargo-leptos/issues/280 & https://github.com/leptos-rs/leptos/issues/2596